### PR TITLE
Removed 2 unnecessary stubbings in BuildHelperTest.java

### DIFF
--- a/src/test/java/hudson/plugins/im/tools/BuildHelperTest.java
+++ b/src/test/java/hudson/plugins/im/tools/BuildHelperTest.java
@@ -66,12 +66,8 @@ public class BuildHelperTest {
             FreeStyleBuild anotherAborted = mock(FreeStyleBuild.class);
             when(build.getResult()).thenReturn(Result.ABORTED);
 
-            when(build.getPreviousBuild()).thenReturn(anotherAborted);
-
             FreeStyleBuild anUnstableBuild = mock(FreeStyleBuild.class);
             when(build.getResult()).thenReturn(Result.UNSTABLE);
-
-            when(anotherAborted.getPreviousBuild()).thenReturn(anUnstableBuild);
 
             assertTrue(ResultTrend.FIXED == ResultTrend.getResultTrend(nextBuild));
         }


### PR DESCRIPTION
In our analysis of the project, we observed that the test `BuildHelperTest.testIsFix` contains 2 unnecessary stubbings.

Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html). 

We propose below a solution to remove the unnecessary stubbings.