### PR TITLE
Removed 1 unnecessary stubbing in CommentCommandTest.java

### DIFF
--- a/src/test/java/hudson/plugins/im/bot/CommentCommandTest.java
+++ b/src/test/java/hudson/plugins/im/bot/CommentCommandTest.java
@@ -46,8 +46,6 @@ public class CommentCommandTest {
         @SuppressWarnings("rawtypes")
         AbstractProject project = mock(AbstractProject.class);
         AbstractBuild<?, ?> build = mock(AbstractBuild.class);
-        when(project.getBuildByNumber(4711)).thenReturn(build);
-
         CommentCommand command = new CommentCommand();
         command.getMessageForJob(project, new Sender("kutzi"),
                 new String[] { "4712", "my comment"}).toString();


### PR DESCRIPTION
In our analysis of the project, we observed that 1) the test `CommentCommandTest.testUnknownBuildNumber` contains 1 unnecessary stubbing.

Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html). 

We propose below a solution to remove the unnecessary stubbing.