### PR TITLE
Removed 4 unnecessary stubbing in BuildCommandTest.java

### DIFF
--- a/src/test/java/hudson/plugins/im/bot/BuildCommandTest.java
+++ b/src/test/java/hudson/plugins/im/bot/BuildCommandTest.java
@@ -98,7 +98,7 @@ public class BuildCommandTest {
         JobProvider jobProvider = mock(JobProvider.class);
         cmd.setJobProvider(jobProvider);
 
-        AbstractProject<?, ?> project = mockProject(jobProvider);
+        AbstractProject<?, ?> project = mockProject2(jobProvider);
         project = mockProject(jobProvider);
         when(project.isParameterized()).thenReturn(Boolean.TRUE);
         when(project.getProperty(ParametersDefinitionProperty.class)).thenReturn(
@@ -194,18 +194,30 @@ public class BuildCommandTest {
     @Test
     public void disabledProjectShouldNotBeScheduled() {
         Bot bot = mock(Bot.class);
-        when(bot.getImId()).thenReturn("hudsonbot");
-
         BuildCommand cmd = new BuildCommand();
         JobProvider jobProvider = mock(JobProvider.class);
         cmd.setJobProvider(jobProvider);
 
-        AbstractProject<?, ?> project = mockProject(jobProvider);
+        AbstractProject<?, ?> project = mockProject3(jobProvider);
         when(project.isBuildable()).thenReturn(false);
 
         Sender sender = new Sender("sender");
         cmd.getReply(bot, sender, new String[]{"build", "project"});
 
         verify(project, times(0)).scheduleBuild(anyInt(), any(Cause.class));
+    }
+
+    private AbstractProject<?, ?> mockProject2(JobProvider jobProvider) {
+        @SuppressWarnings("rawtypes")
+        AbstractProject project = mock(FreeStyleProject.class);
+        return project;
+    }
+
+    private AbstractProject<?, ?> mockProject3(JobProvider jobProvider) {
+        @SuppressWarnings("rawtypes")
+        AbstractProject project = mock(FreeStyleProject.class);
+        when(jobProvider.getJobByNameOrDisplayName(Mockito.anyString())).thenReturn(project);
+        when(project.hasPermission(Item.BUILD)).thenReturn(Boolean.TRUE);
+        return project;
     }
 }


### PR DESCRIPTION
In our analysis of the project, we observed that 

1) the test BuildCommandTest.disabledProjectShouldNotBeScheduled contains 1 unnecessary stubbing;

2) 3 unnecessary stubbings which stubbed `getJobByNameOrDisplayName` method, `hasPermission` method, `isBuildable` method are created but never executed by one method call in the test `BuildCommandTest.parametersFromCommandShouldBePassedToBuild`;

3) 1 unnecessary stubbing which stubbed `isBuildable` method is created but never executed by the test `BuildCommandTest.disabledProjectShouldNotBeScheduled`.

Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html).

We propose below a solution to remove the unnecessary stubbing.